### PR TITLE
添加了搜索功能多个功能的汉语本地化，并添加了外观切换动画

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -19,6 +19,40 @@ export default defineConfig({
     hostname: "https://siiway.org",
   },
 
+  themeConfig: {
+    // 搜索功能 https://vitepress.dev/zh/reference/default-theme-search
+    search: {
+      provider: 'local',
+      options: {
+        locales: {
+          zh: { // 此处为翻译的语言
+            translations: {
+              button: {
+                buttonText: '搜索',
+                 buttonAriaLabel: '搜索'
+              },
+              modal: {
+                displayDetails: '显示详细列表',
+                 resetButtonTitle: '重置搜索',
+                 backButtonTitle: '关闭搜索',
+                noResultsText: '没有结果',
+                 footer: {
+                    selectText: '选择',
+                    selectKeyAriaLabel: '输入',
+                    navigateText: '导航',
+                    navigateUpKeyAriaLabel: '上箭头',
+                    navigateDownKeyAriaLabel: '下箭头',
+                    closeText: '关闭',
+                    closeKeyAriaLabel: 'Esc'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+  }
+
   locales: {
     // === 中文版 (zh) ===
     zh: {

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -8,6 +8,28 @@ const members = Object.entries(rawMembers).map(([key, value]) => {
   };
 });
 
+const zhSearchTranslations = {
+  button: {
+    buttonText: "搜索",
+    buttonAriaLabel: "搜索",
+  },
+  modal: {
+    displayDetails: "显示详细列表",
+    resetButtonTitle: "重置搜索",
+    backButtonTitle: "关闭搜索",
+    noResultsText: "没有结果",
+    footer: {
+      selectText: "选择",
+      selectKeyAriaLabel: "输入",
+      navigateText: "导航",
+      navigateUpKeyAriaLabel: "上箭头",
+      navigateDownKeyAriaLabel: "下箭头",
+      closeText: "关闭",
+      closeKeyAriaLabel: "Esc",
+    },
+  },
+};
+
 export default defineConfig({
   head: [
     ["link", { rel: "icon", href: "/favicon.svg" }],
@@ -21,39 +43,12 @@ export default defineConfig({
 
   themeConfig: {
     // 左侧侧边栏上方的图标
-    logo: '/favicon.svg',
+    logo: "/favicon.svg",
     // 搜索功能 https://vitepress.dev/zh/reference/default-theme-search
     search: {
-      provider: 'local',
-      options: {
-        locales: {
-          zh: { // 此处为翻译的语言
-            translations: {
-              button: {
-                buttonText: '搜索',
-                 buttonAriaLabel: '搜索'
-              },
-              modal: {
-                displayDetails: '显示详细列表',
-                 resetButtonTitle: '重置搜索',
-                 backButtonTitle: '关闭搜索',
-                noResultsText: '没有结果',
-                 footer: {
-                    selectText: '选择',
-                    selectKeyAriaLabel: '输入',
-                    navigateText: '导航',
-                    navigateUpKeyAriaLabel: '上箭头',
-                    navigateDownKeyAriaLabel: '下箭头',
-                    closeText: '关闭',
-                    closeKeyAriaLabel: 'Esc'
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
+      provider: "local",
+    },
+  },
 
   locales: {
     // === 中文版 (zh) ===
@@ -151,9 +146,18 @@ export default defineConfig({
         },
         // 汉化了 "Previous page" 与 "Next page"。
         docFooter: {
-          prev: '上一篇',
-          next: '下一篇'
-        }
+          prev: "上一篇",
+          next: "下一篇",
+        },
+        search: {
+          options: {
+            locales: {
+              zh: {
+                translations: zhSearchTranslations,
+              },
+            },
+          },
+        },
       },
     },
 

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -50,8 +50,8 @@ export default defineConfig({
                   }
                 }
               }
-            },
-  }
+            }
+          },
 
   locales: {
     // === 中文版 (zh) ===

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -20,6 +20,8 @@ export default defineConfig({
   },
 
   themeConfig: {
+    // 左侧侧边栏上方的图标
+    logo: '/favicon.svg',
     // 搜索功能 https://vitepress.dev/zh/reference/default-theme-search
     search: {
       provider: 'local',

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -109,6 +109,10 @@ export default defineConfig({
         lastUpdated: {
           text: "本页最后更新于",
         },
+        // 将"On this page"改为中文
+        outline: {
+          label: '本页目录'
+        }
       },
     },
 

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -112,6 +112,11 @@ export default defineConfig({
         // 将"On this page"改为中文
         outline: {
           label: '本页目录'
+        },
+        // 汉化了 "Previous page" 与 "Next page"。
+        docFooter: {
+          prev: '上一篇',
+          next: '下一篇'
         }
       },
     },

--- a/.vitepress/theme/CustomLayout.vue
+++ b/.vitepress/theme/CustomLayout.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import DefaultTheme from "vitepress/theme";
 import AprilFools from "./AprilFools.vue";
+import ThemeLayout from "./ThemeLayout.vue";
 
 const { Layout } = DefaultTheme;
 </script>
 
 <template>
-  <Layout>
+  <ThemeLayout>
     <template #layout-bottom>
       <AprilFools />
     </template>
-  </Layout>
+  </ThemeLayout>
 </template>

--- a/.vitepress/theme/ThemeLayout.vue
+++ b/.vitepress/theme/ThemeLayout.vue
@@ -5,8 +5,11 @@ import DefaultTheme from 'vitepress/theme'
 import { nextTick, provide } from 'vue'
 
 const { isDark } = useData()
+const { Layout } = DefaultTheme
+const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined'
 
 const enableTransitions = () =>
+  isBrowser &&
   'startViewTransition' in document &&
   window.matchMedia('(prefers-reduced-motion: no-preference)').matches
 
@@ -19,8 +22,8 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
   const clipPath = [
     `circle(0px at ${x}px ${y}px)`,
     `circle(${Math.hypot(
-      Math.max(x, innerWidth - x),
-      Math.max(y, innerHeight - y)
+      Math.max(x, window.innerWidth - x),
+      Math.max(y, window.innerHeight - y)
     )}px at ${x}px ${y}px)`
   ]
 
@@ -42,7 +45,11 @@ provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
 </script>
 
 <template>
-  <DefaultTheme.Layout />
+  <Layout>
+    <template #layout-bottom>
+      <slot name="layout-bottom" />
+    </template>
+  </Layout>
 </template>
 
 <style>

--- a/.vitepress/theme/ThemeLayout.vue
+++ b/.vitepress/theme/ThemeLayout.vue
@@ -1,0 +1,72 @@
+<!-- 官方的外观切换组件： https://vitepress.dev/zh/guide/extending-default-theme#on-appearance-toggle -->
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
+import { nextTick, provide } from 'vue'
+
+const { isDark } = useData()
+
+const enableTransitions = () =>
+  'startViewTransition' in document &&
+  window.matchMedia('(prefers-reduced-motion: no-preference)').matches
+
+provide('toggle-appearance', async ({ clientX: x, clientY: y }: MouseEvent) => {
+  if (!enableTransitions()) {
+    isDark.value = !isDark.value
+    return
+  }
+
+  const clipPath = [
+    `circle(0px at ${x}px ${y}px)`,
+    `circle(${Math.hypot(
+      Math.max(x, innerWidth - x),
+      Math.max(y, innerHeight - y)
+    )}px at ${x}px ${y}px)`
+  ]
+
+  await document.startViewTransition(async () => {
+    isDark.value = !isDark.value
+    await nextTick()
+  }).ready
+
+  document.documentElement.animate(
+    { clipPath: isDark.value ? clipPath.reverse() : clipPath },
+    {
+      duration: 300,
+      easing: 'ease-in',
+      fill: 'forwards',
+      pseudoElement: `::view-transition-${isDark.value ? 'old' : 'new'}(root)`
+    }
+  )
+})
+</script>
+
+<template>
+  <DefaultTheme.Layout />
+</template>
+
+<style>
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root),
+.dark::view-transition-new(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root),
+.dark::view-transition-old(root) {
+  z-index: 9999;
+}
+
+.VPSwitchAppearance {
+  width: 22px !important;
+}
+
+.VPSwitchAppearance .check {
+  transform: none !important;
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import "./style.css";
 import type { Theme } from "vitepress";
 import CustomLayout from "./CustomLayout.vue";
 
+
 export default {
   extends: DefaultTheme,
   Layout: CustomLayout,


### PR DESCRIPTION
# 某些Bug：
## 外观切换动画：
在切换外观时，其他动画将暂时停止一会


# 以下为所有更新功能原版与改版预览
## 搜索功能与本地化预览：
链接： https://sw-hj.pages.dev/

视频：

[Screen recording 2026-04-24 21.49.08.webm](https://github.com/user-attachments/assets/34e89841-a283-4636-a008-d6112a4457e9)

## 外观动画
链接： https://sw-hj.pages.dev/

视频：

[Screen recording 2026-04-24 21.50.29.webm](https://github.com/user-attachments/assets/788dc49e-879f-42ca-85b1-400e7d3ec2c4)

## 额外添加的语言中文本地化：
### "On this page"：
原版：
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/88fa3bbf-e3f1-458a-aaf1-581ad8352ace" />
改版：
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/68b11fd5-e81e-486a-9e9b-f6cbb9a9bc5d" />

### Previous & Next Page
原版：
<img width="771" height="180" alt="Screenshot 2026-04-24 21 53 21" src="https://github.com/user-attachments/assets/678fe176-3200-4e3e-92a7-3792898fd926" />
改版：
<img width="771" height="180" alt="image" src="https://github.com/user-attachments/assets/a1dafa1b-41dc-41ea-98ff-82f33fec4e1d" />

## 上栏图标添加
原版：
<img width="1365" height="67" alt="image" src="https://github.com/user-attachments/assets/a1e577d7-2996-4282-9a4c-163699524676" />
改版：
<img width="1365" height="67" alt="image" src="https://github.com/user-attachments/assets/736d6c8b-d6f4-4b33-ac1f-51d137e4920b" />

注意，有些内容靠了AI的帮助，但经测试、可以完全正常使用

## Summary by Sourcery

添加本地化搜索界面和中文 UI 文本，并引入自定义主题布局以支持带动画效果的外观（深色/浅色）切换。

新功能：
- 启用内置本地搜索，并为搜索界面提供中文翻译。
- 在 VitePress 主题页眉中添加站点 Logo 图标。

增强改进：
- 为中文语言环境本地化 “On this page” 大纲标签以及上一页/下一页页脚文案。
- 使用自定义主题布局包裹默认布局，通过视图过渡提供带动画效果的外观切换，并调整外观切换控件的样式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add localized search UI and Chinese UI text, and introduce a custom themed layout to support an animated appearance (dark/light) toggle.

New Features:
- Enable built-in local search with Chinese translations for the search UI.
- Add a site logo icon to the VitePress theme header.

Enhancements:
- Localize "On this page" outline label and previous/next page footer text for the Chinese locale.
- Wrap the default layout in a custom theme layout that provides an animated appearance toggle using view transitions and adjusts the appearance switch styling.

</details>