### PR TITLE
fix: 恢复自定义字体，修复成员卡片布局与换行

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -1,4 +1,11 @@
+@import 'lxgw-wenkai-screen-web/lxgwwenkaiscreen/result.css';
+@import 'noto-sans-sc/noto_sans_sc_regular/css.css';
+@import 'noto-sans-sc/noto_sans_sc_medium/css.css';
+@import 'noto-sans-sc/noto_sans_sc_bold/css.css';
+
 :root {
+  --vp-font-family-base: 'LXGW WenKai Screen', 'Noto Sans SC', system-ui, -apple-system, sans-serif;
+
   --siiway-primary: #109595;
   --siiway-primary-hover: #0c7a7a;
   --siiway-indigo: #24047b;
@@ -19,6 +26,15 @@ html {
 body {
   font-synthesis: none;
   -webkit-font-synthesis: none;
+}
+
+h1, h2, h3, h4, h5, h6,
+strong, b, th,
+.VPNavBarMenuLink.active,
+.home-title,
+.home-subtitle,
+.home-btn {
+  font-family: 'Noto Sans SC', 'LXGW WenKai Screen', system-ui, -apple-system, sans-serif;
 }
 
 .dark {
@@ -537,6 +553,7 @@ body {
 .member-name {
   font-weight: 600;
   font-size: 16px;
+  font-family: 'Noto Sans SC', 'LXGW WenKai Screen', system-ui, sans-serif;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -472,17 +472,16 @@ strong, b, th,
 
 .members-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
-  margin-top: 24px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin: 24px -48px 0;
 }
 
 .member-card {
   display: flex;
   flex-direction: row;
-  align-items: center;
-  height: 80px;
-  padding: 12px 16px;
+  height: 104px;
+  padding: 0 14px;
   background: var(--vp-c-bg-soft);
   border-radius: 12px;
   text-decoration: none !important;
@@ -522,12 +521,13 @@ strong, b, th,
 }
 
 .member-avatar {
+  align-self: center;
   width: 56px;
   height: 56px;
   min-width: 56px;
   border-radius: 50%;
   overflow: hidden;
-  margin-right: 16px;
+  margin-right: 12px;
   background: var(--vp-c-divider);
   transition:
     width 0.3s,
@@ -546,8 +546,10 @@ strong, b, th,
 .member-info {
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
   overflow: hidden;
   min-width: 0;
+  padding-top: 12px;
 }
 
 .member-name {
@@ -560,12 +562,15 @@ strong, b, th,
 }
 
 .member-motto {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--vp-c-text-2);
   margin-top: 4px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-all;
   transition: color 0.3s;
 }
 
@@ -581,20 +586,16 @@ strong, b, th,
 @media (max-width: 900px) {
   .members-grid {
     grid-template-columns: repeat(2, 1fr);
+    margin-left: -24px;
+    margin-right: -24px;
   }
 }
 
 @media (max-width: 600px) {
   .members-grid {
     grid-template-columns: 1fr;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .member-card,
-  .member-avatar,
-  .member-motto {
-    transition: none !important;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "homepage": "https://siiway.org",
   "dependencies": {
+    "lxgw-wenkai-screen-web": "^1.522.0",
+    "noto-sans-sc": "^37.0.0",
     "@vueuse/core": "12.8.2",
     "vitepress": "^1.6.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@vueuse/core':
         specifier: 12.8.2
         version: 12.8.2
+      lxgw-wenkai-screen-web:
+        specifier: ^1.522.0
+        version: 1.522.0
+      noto-sans-sc:
+        specifier: ^37.0.0
+        version: 37.0.0
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.53.0)(@types/node@25.9.1)(postcss@8.5.15)(search-insights@2.17.3)
@@ -643,6 +649,9 @@ packages:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
 
+  lxgw-wenkai-screen-web@1.522.0:
+    resolution: {integrity: sha512-LH1nDJz9prHgMYNKErg8XpDEIhs9+1bf6hPVKviy29be1r6Z4AXXbo9uuwmOH2hAzKMbe3kZ5+rzJ9zb/58+jw==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -677,6 +686,9 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  noto-sans-sc@37.0.0:
+    resolution: {integrity: sha512-1gPL5phDXMTIWsjwxk9674DVIyf+ANIk4UKlWEKGIDYPQqBJpDZ0Y2gfAkXr0j/+5S1EcJ7FgLz7f5uSQsVnaw==}
 
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
@@ -1400,6 +1412,8 @@ snapshots:
 
   is-what@5.5.0: {}
 
+  lxgw-wenkai-screen-web@1.522.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1440,6 +1454,8 @@ snapshots:
   mitt@3.0.1: {}
 
   nanoid@3.3.12: {}
+
+  noto-sans-sc@37.0.0: {}
 
   oniguruma-to-es@3.1.1:
     dependencies:


### PR DESCRIPTION
## 变更概要

本次 PR 恢复被移除的自定义字体系统，并修复成员卡片的多项布局问题。

---

### 恢复自定义字体

- 重新安装 \lxgw-wenkai-screen-web\ + \
oto-sans-sc\ 依赖
- 恢复 CSS 字体导入、\--vp-font-family-base\、粗体字体规则
- 正文霞鹭文楷，标题/粗体思源黑体，\ont-synthesis: none\ 防止伪粗体
- 未恢复 FontSwitcher 字体切换组件

### 成员卡片修复

- 卡片从 2 列改为 3 列，通过负 margin 突破 VitePress 内容容器宽度限制
- 卡片高度提升至 104px，座右铭支持 2 行，\word-break: break-all\ 英文任意处断行
- 头像从弹性居中改为 \lign-self: center\，文本区域固定 \padding-top\ —— hover 时头像消失不再造成文字上下抖动
- 头像 56px，座右铭 14px 字重
- 重复的 \prefers-reduced-motion\ 块已清理

---

## 检查清单

- [x] 构建通过 (\pnpm build\)
- [x] 中英文侧边栏均正确
- [x] 字体正常加载
- [x] 卡片聚焦时无布局抖动

## Summary by Sourcery

恢复自定义字体设置，并调整成员卡片布局和排版，以提升可读性和稳定性。

Bug Fixes:
- 修复成员卡片布局，防止在悬停/聚焦时内容发生位移，并改进对较长座右铭的换行表现。

Enhancements:
- 重新引入并配置 LXGW WenKai Screen 和 Noto Sans SC 作为正文和标题的主要字体。
- 优化成员网格为桌面端三列布局，并调整响应式边距以及卡片尺寸和间距。

Build:
- 将 LXGW WenKai Screen 和 Noto Sans SC 字体包添加为项目依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore the custom font setup and adjust member card layout and typography for better readability and stability.

Bug Fixes:
- Fix member card layout to prevent hover/focus-induced content shifting and improve wrapping of long mottos.

Enhancements:
- Reintroduce and configure LXGW WenKai Screen and Noto Sans SC as the primary typography across body and headings.
- Refine member grid to three-column layout on desktop with responsive margins and updated card sizing and spacing.

Build:
- Add LXGW WenKai Screen and Noto Sans SC font packages as project dependencies.

</details>