### PR TITLE
style: reduce member card height and info padding to minimize whitespace

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -480,7 +480,7 @@ strong, b, th,
 .member-card {
   display: flex;
   flex-direction: row;
-  height: 104px;
+  height: 92px;
   padding: 0 14px;
   background: var(--vp-c-bg-soft);
   border-radius: 12px;
@@ -549,7 +549,7 @@ strong, b, th,
   justify-content: flex-start;
   overflow: hidden;
   min-width: 0;
-  padding-top: 12px;
+  padding-top: 10px;
 }
 
 .member-name {

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -1,4 +1,11 @@
+@import 'lxgw-wenkai-screen-web/lxgwwenkaiscreen/result.css';
+@import 'noto-sans-sc/noto_sans_sc_regular/css.css';
+@import 'noto-sans-sc/noto_sans_sc_medium/css.css';
+@import 'noto-sans-sc/noto_sans_sc_bold/css.css';
+
 :root {
+  --vp-font-family-base: 'LXGW WenKai Screen', 'Noto Sans SC', system-ui, -apple-system, sans-serif;
+
   --siiway-primary: #109595;
   --siiway-primary-hover: #0c7a7a;
   --siiway-indigo: #24047b;
@@ -19,6 +26,15 @@ html {
 body {
   font-synthesis: none;
   -webkit-font-synthesis: none;
+}
+
+h1, h2, h3, h4, h5, h6,
+strong, b, th,
+.VPNavBarMenuLink.active,
+.home-title,
+.home-subtitle,
+.home-btn {
+  font-family: 'Noto Sans SC', 'LXGW WenKai Screen', system-ui, -apple-system, sans-serif;
 }
 
 .dark {
@@ -537,6 +553,7 @@ body {
 .member-name {
   font-weight: 600;
   font-size: 16px;
+  font-family: 'Noto Sans SC', 'LXGW WenKai Screen', system-ui, sans-serif;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -472,17 +472,16 @@ strong, b, th,
 
 .members-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
-  margin-top: 24px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin: 24px -48px 0;
 }
 
 .member-card {
   display: flex;
   flex-direction: row;
-  align-items: center;
-  height: 80px;
-  padding: 12px 16px;
+  height: 104px;
+  padding: 0 14px;
   background: var(--vp-c-bg-soft);
   border-radius: 12px;
   text-decoration: none !important;
@@ -522,12 +521,13 @@ strong, b, th,
 }
 
 .member-avatar {
+  align-self: center;
   width: 56px;
   height: 56px;
   min-width: 56px;
   border-radius: 50%;
   overflow: hidden;
-  margin-right: 16px;
+  margin-right: 12px;
   background: var(--vp-c-divider);
   transition:
     width 0.3s,
@@ -546,8 +546,10 @@ strong, b, th,
 .member-info {
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
   overflow: hidden;
   min-width: 0;
+  padding-top: 12px;
 }
 
 .member-name {
@@ -560,12 +562,15 @@ strong, b, th,
 }
 
 .member-motto {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--vp-c-text-2);
   margin-top: 4px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-all;
   transition: color 0.3s;
 }
 
@@ -581,20 +586,16 @@ strong, b, th,
 @media (max-width: 900px) {
   .members-grid {
     grid-template-columns: repeat(2, 1fr);
+    margin-left: -24px;
+    margin-right: -24px;
   }
 }
 
 @media (max-width: 600px) {
   .members-grid {
     grid-template-columns: 1fr;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .member-card,
-  .member-avatar,
-  .member-motto {
-    transition: none !important;
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "homepage": "https://siiway.org",
   "dependencies": {
+    "lxgw-wenkai-screen-web": "^1.522.0",
+    "noto-sans-sc": "^37.0.0",
     "@vueuse/core": "12.8.2",
     "vitepress": "^1.6.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@vueuse/core':
         specifier: 12.8.2
         version: 12.8.2
+      lxgw-wenkai-screen-web:
+        specifier: ^1.522.0
+        version: 1.522.0
+      noto-sans-sc:
+        specifier: ^37.0.0
+        version: 37.0.0
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.53.0)(@types/node@25.9.1)(postcss@8.5.15)(search-insights@2.17.3)
@@ -643,6 +649,9 @@ packages:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
 
+  lxgw-wenkai-screen-web@1.522.0:
+    resolution: {integrity: sha512-LH1nDJz9prHgMYNKErg8XpDEIhs9+1bf6hPVKviy29be1r6Z4AXXbo9uuwmOH2hAzKMbe3kZ5+rzJ9zb/58+jw==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -677,6 +686,9 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  noto-sans-sc@37.0.0:
+    resolution: {integrity: sha512-1gPL5phDXMTIWsjwxk9674DVIyf+ANIk4UKlWEKGIDYPQqBJpDZ0Y2gfAkXr0j/+5S1EcJ7FgLz7f5uSQsVnaw==}
 
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
@@ -1400,6 +1412,8 @@ snapshots:
 
   is-what@5.5.0: {}
 
+  lxgw-wenkai-screen-web@1.522.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1440,6 +1454,8 @@ snapshots:
   mitt@3.0.1: {}
 
   nanoid@3.3.12: {}
+
+  noto-sans-sc@37.0.0: {}
 
   oniguruma-to-es@3.1.1:
     dependencies:


### PR DESCRIPTION
成员卡片高度从 104px 降至 92px，信息块 padding-top 从 12px 降至 10px，减少座右铭上下多余留白。

## Summary by Sourcery

优化成员列表的布局和排版，以提升信息密度和可读性。

改进内容：
- 使用适合中文的字体栈，为正文和标题应用 LXGW WenKai Screen 和 Noto Sans SC。
- 调整成员网格布局、卡片尺寸和间距，以便在不同断点下更好地利用横向空间。
- 改进成员卡片内容的排版，包括头像对齐、姓名样式，以及多行座右铭的排版与更合理的行数截断。

构建：
- 将 `lxgw-wenkai-screen-web` 和 `noto-sans-sc` 字体包添加为运行时依赖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the member listing layout and typography to improve visual density and readability.

Enhancements:
- Apply new Chinese-friendly font stack using LXGW WenKai Screen and Noto Sans SC for body and headings.
- Adjust member grid layout, card dimensions, and spacing for better use of horizontal space across breakpoints.
- Improve member card content typography, including avatar alignment, name styling, and multi-line mottos with better line clamping.

Build:
- Add lxgw-wenkai-screen-web and noto-sans-sc font packages as runtime dependencies.

</details>